### PR TITLE
Fix for token cache bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.queryService</groupId>
     <artifactId>Salesforce-CDP-jdbc</artifactId>
-    <version>1.4</version>
+    <version>1.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
@@ -46,18 +46,20 @@ public abstract class QueryServiceAbstractStatement {
 
     protected boolean paginationRequired;
 
+    private QueryExecutor queryExecutor;
+
     public QueryServiceAbstractStatement(QueryServiceConnection queryServiceConnection,
                                          int resultSetType,
                                          int resultSetConcurrency) {
         this.connection = queryServiceConnection;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
+        this.queryExecutor = createQueryExecutor();
     }
 
     public ResultSet executeQuery(String sql) throws SQLException {
         try {
             this.sql = sql;
-            QueryExecutor queryExecutor = connection.getQueryExecutor();
             boolean isTableauQuery = isTableauQuery();
             Response response = queryExecutor.executeQuery(sql, isTableauQuery ? Optional.of(Constants.MAX_LIMIT) : Optional.empty(), Optional.of(offset), isTableauQuery ? Optional.of("1 ASC") : Optional.empty());
             if (!response.isSuccessful()) {
@@ -119,5 +121,9 @@ public abstract class QueryServiceAbstractStatement {
 
     public ResultSet getNextPage() throws SQLException {
         return this.executeQuery(sql);
+    }
+
+    protected QueryExecutor createQueryExecutor() {
+        return new QueryExecutor(connection);
     }
 }

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
@@ -58,8 +58,12 @@ public class QueryServiceMetadataTest {
         Properties properties = new Properties();
         properties.put(Constants.BASE_URL, "https://mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com");
         properties.put(Constants.CORETOKEN, "Test_Token");
-        doReturn(queryExecutor).when(queryServiceConnection).getQueryExecutor();
-        queryServiceMetadata = new QueryServiceMetadata(queryServiceConnection, "https://mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com", properties);
+        queryServiceMetadata = new QueryServiceMetadata(queryServiceConnection, "https://mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com", properties){
+            @Override
+            protected QueryExecutor createQueryExecutor() {
+                return queryExecutor;
+            }
+        };
     }
 
     @Test

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceStatementTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceStatementTest.java
@@ -52,16 +52,20 @@ public class QueryServiceStatementTest {
     @Mock
     private QueryServiceConnection queryServiceConnection;
 
-    @Mock
     private QueryExecutor queryExecutor;
 
     private QueryServiceStatement queryServiceStatement;
 
     @Before
     public void init() {
-        doReturn(queryExecutor).when(queryServiceConnection).getQueryExecutor();
+        queryExecutor = mock(QueryExecutor.class);
         queryServiceStatement = new QueryServiceStatement(queryServiceConnection, ResultSet.TYPE_FORWARD_ONLY,
-                ResultSet.CONCUR_READ_ONLY);
+                ResultSet.CONCUR_READ_ONLY) {
+            @Override
+            protected QueryExecutor createQueryExecutor() {
+                return queryExecutor;
+            }
+        };
     }
 
     @Test

--- a/src/test/java/com/salesforce/cdp/queryservice/util/TokenHelperTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/util/TokenHelperTest.java
@@ -81,7 +81,8 @@ public class TokenHelperTest {
                 body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
         when(remoteCall.execute()).thenReturn(response);
         when(client.newCall(any())).thenReturn(remoteCall);
-        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithTenantUrl(properties, client);
+        Token token = TokenHelper.getToken(properties, client);
+        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithUrl(token);
         Assert.assertEquals(tokenWithUrlMap.get(Constants.ACCESS_TOKEN), "Bearer 1234");
         Assert.assertEquals(tokenWithUrlMap.get(Constants.TENANT_URL), "abcd");
     }
@@ -99,7 +100,8 @@ public class TokenHelperTest {
         Field tokenCacheField = TokenHelper.class.getDeclaredField("tokenCache");
         tokenCacheField.setAccessible(true);
         tokenCacheField.set(null, tokenCache);
-        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithTenantUrl(properties, client);
+        Token cachedToken = TokenHelper.getToken(properties, client);
+        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithUrl(cachedToken);
         Assert.assertEquals(tokenWithUrlMap.get(Constants.ACCESS_TOKEN), "Bearer 1234");
         Assert.assertEquals(tokenWithUrlMap.get(Constants.TENANT_URL), "abcd");
     }
@@ -128,7 +130,8 @@ public class TokenHelperTest {
                 body(ResponseBody.create(TOKEN_EXCHANGE.getResponse(), MediaType.parse("application/json"))).build();
         when(remoteCall.execute()).thenReturn(renewCoreTokenResponse).thenReturn(offCoreResponse);
         when(client.newCall(any())).thenReturn(remoteCall);
-        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithTenantUrl(properties, client);
+        Token cachedToken = TokenHelper.getToken(properties, client);
+        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithUrl(cachedToken);
         Assert.assertEquals(tokenWithUrlMap.get(Constants.ACCESS_TOKEN), "Bearer 1234");
         Assert.assertEquals(tokenWithUrlMap.get(Constants.TENANT_URL), "abcd");
     }
@@ -144,7 +147,7 @@ public class TokenHelperTest {
         when(client.newCall(any())).thenReturn(remoteCall);
         exceptionRule.expect(SQLException.class);
         exceptionRule.expectMessage(Messages.TOKEN_EXCHANGE_FAILURE);
-        TokenHelper.getTokenWithTenantUrl(properties, client);
+        TokenHelper.getToken(properties, client);
     }
 
     @Test
@@ -168,7 +171,8 @@ public class TokenHelperTest {
                 body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
         when(remoteCall.execute()).thenReturn(response);
         when(client.newCall(any())).thenReturn(remoteCall);
-        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithTenantUrl(properties, client);
+        Token cachedToken = TokenHelper.getToken(properties, client);
+        Map<String, String> tokenWithUrlMap = TokenHelper.getTokenWithUrl(cachedToken);
         Assert.assertEquals(tokenWithUrlMap.get(Constants.ACCESS_TOKEN), "Bearer 1234");
         Assert.assertEquals(tokenWithUrlMap.get(Constants.TENANT_URL), "abcd");
     }
@@ -187,7 +191,7 @@ public class TokenHelperTest {
         exceptionRule.expect(SQLException.class);
         exceptionRule.expectMessage(Messages.TOKEN_EXCHANGE_FAILURE);
         try {
-            TokenHelper.getTokenWithTenantUrl(properties, client);
+            TokenHelper.getToken(properties, client);
         } finally {
             verify(client, times(2)).newCall(eventCaptor.capture());
             Request request = eventCaptor.getValue();


### PR DESCRIPTION
Fixing the token caching issue for username and password flow.
Making QueryExecutor at statement level so that multiple statements can be executed with one connection.