### PR TITLE
Add retry mechanism and other changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
             <version>3.20.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>2.4.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
@@ -81,7 +81,7 @@ public abstract class QueryServiceAbstractStatement {
             return createResultSetFromResponse(queryServiceResponse);
         } catch (IOException e) {
             log.error("Exception while running the query", e);
-            throw new SQLException(QUERY_EXCEPTION);
+            throw new SQLException(QUERY_EXCEPTION, e);
         }
     }
 
@@ -113,8 +113,8 @@ public abstract class QueryServiceAbstractStatement {
         if (queryServiceResponse.getMetadata() == null && queryServiceResponse.getRowCount() > 0) {
             Map<String, Object> row = queryServiceResponse.getData().get(0);
             columnNames = new ArrayList<>(row.keySet());
-            columnTypes = Collections.EMPTY_LIST;
-            columnTypeIds = Collections.EMPTY_LIST;
+            columnTypes = Collections.emptyList();
+            columnTypeIds = Collections.emptyList();
         } else if (queryServiceResponse.getMetadata() != null) {
             log.info("Metadata is {}", queryServiceResponse.getMetadata());
             Map<String, Type> metadata = queryServiceResponse.getMetadata();
@@ -124,9 +124,9 @@ public abstract class QueryServiceAbstractStatement {
                 columnTypeIds.add(metadata.get(columnName).getTypeCode());
             }
         } else {
-            columnNames = Collections.EMPTY_LIST;
-            columnTypes = Collections.EMPTY_LIST;
-            columnTypeIds = Collections.EMPTY_LIST;
+            columnNames = Collections.emptyList();
+            columnTypes = Collections.emptyList();
+            columnTypeIds = Collections.emptyList();
         }
         resultSetMetaData = new QueryServiceResultSetMetaData(columnNames, columnTypes, columnTypeIds);
         log.trace("Received column names are {}", columnNames);

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -663,7 +663,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
             return createTableResultSet(metadataResponse, tableNamePattern);
         } catch (IOException e) {
             log.info("Exception while getting metadata from query service", e);
-            throw new SQLException(METADATA_EXCEPTION);
+            throw new SQLException(METADATA_EXCEPTION, e);
         } finally {
             queryServiceConnection.close();
         }
@@ -699,7 +699,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
             return createColumnResultSet(metadataResponse, tableNamePattern);
         } catch (IOException e) {
             log.error("Exception while getting metadata from query service", e);
-            throw new SQLException(METADATA_EXCEPTION);
+            throw new SQLException(METADATA_EXCEPTION, e);
         } finally {
             queryServiceConnection.close();
         }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -78,6 +78,7 @@ public class Constants {
     public static final String USER = "user";
     public static final String USER_NAME = "userName";
     public static final String PD = "password";
+    public static final String MAX_RETRIES = "maxRetries";
 
     // Response Constants
     public static final String MESSAGE = "message";

--- a/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
@@ -26,21 +26,23 @@ import okhttp3.Response;
 import org.apache.commons.collections4.MapUtils;
 
 import java.io.IOException;
-import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Map;
 
 @Slf4j
 public class HttpHelper {
 
-    public static void handleErrorResponse(Response response, String propertyName) throws IOException, SQLException {
+    public static void handleErrorResponse(Response response, String propertyName) throws IOException {
         handleErrorResponse(response.body().string(), propertyName);
     }
 
-    public static void handleErrorResponse(String response, String propertyName) throws IOException, SQLException {
+    public static void handleErrorResponse(String response, String propertyName) throws IOException {
         ObjectNode node = new ObjectMapper().readValue(response, ObjectNode.class);
         JsonNode jsonNode = node.get(propertyName);
-        String message = jsonNode == null ? String.format("Property %s is not defined", propertyName) : node.get(propertyName).asText();
-        throw new SQLException(message);
+        String message = jsonNode == null ?
+                String.format(Locale.ROOT, "Property %s is not defined", propertyName) :
+                node.get(propertyName).asText();
+        throw new IOException(message);
     }
 
     public static <T> T handleSuccessResponse(Response response, Class<T> type, boolean cacheResponse) throws IOException {
@@ -60,11 +62,9 @@ public class HttpHelper {
     protected static Request buildRequest(String method, String url, RequestBody body, Map<String, String> headers) {
         Request.Builder builder = new Request.Builder()
                 .url(url)
-                .method(method, body == null ? null : body);
+                .method(method, body);
         if (!MapUtils.isEmpty(headers)) {
-            for (String key : headers.keySet()) {
-                builder.addHeader(key, headers.get(key));
-            }
+            headers.forEach(builder::addHeader);
         }
         if (!headers.containsKey(Constants.USER_AGENT)) {
             builder.addHeader(Constants.USER_AGENT, Constants.USER_AGENT_VALUE);

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Messages.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Messages.java
@@ -8,4 +8,6 @@ public class Messages {
 
     public static String METADATA_EXCEPTION = "Failed to get the metadata. Please try again.";
 
+    public static String TOKEN_FETCH_FAILURE = "Retrieving Token failed. Please try again.";
+
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Messages.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Messages.java
@@ -1,5 +1,6 @@
 package com.salesforce.cdp.queryservice.util;
 
+// todo: replace messages with error codes or include codes with msg
 public class Messages {
 
     public static String TOKEN_EXCHANGE_FAILURE = "Token exchange failed. Please login again.";
@@ -9,5 +10,9 @@ public class Messages {
     public static String METADATA_EXCEPTION = "Failed to get the metadata. Please try again.";
 
     public static String TOKEN_FETCH_FAILURE = "Retrieving Token failed. Please try again.";
+
+    public static String FAILED_LOGIN = "Failed to login. Please check credentials";
+
+    public static String RENEW_TOKEN = "Failed to Renew Token. Please retry";
 
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
@@ -143,6 +143,7 @@ public class QueryExecutor {
         if (connection.getToken() != null && TokenHelper.isAlive(connection.getToken())) {
             return TokenHelper.getTokenWithUrl(connection.getToken());
         }
+        // todo: add a wrapper for retry mechanism
         RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
                 .handle(TokenException.class)
                 .withMaxRetries(3);
@@ -154,7 +155,10 @@ public class QueryExecutor {
                         return TokenHelper.getTokenWithUrl(token);
                     });
         } catch (FailsafeException e) {
-            throw new SQLException(e.getCause());
+            if (e.getCause() != null) {
+                throw new SQLException(e.getCause().getMessage(), e.getCause());
+            }
+            throw new SQLException(e);
         }
     }
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
@@ -147,10 +147,14 @@ public class QueryExecutor {
             return TokenHelper.getTokenWithUrl(connection.getToken());
         }
         // todo: add a wrapper for retry mechanism
+        //  check if delay or backoff need to introduced b/w each retry
         RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
                 .handle(TokenException.class)
                 .withMaxRetries(getMaxRetries(connection.getClientInfo()));
         try {
+            // failsafe executes the given block and returns the results
+            // the failures are handled according to the policies specified
+            // Here, only one policy is used i.e, retry policy
             return Failsafe.with(retryPolicy)
                     .get(() -> {
                         Token token = TokenHelper.getToken(connection.getClientInfo(), client);

--- a/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
@@ -128,9 +128,12 @@ public class QueryExecutor {
         if (connection.getToken() != null && TokenHelper.isAlive(connection.getToken())) {
             return TokenHelper.getTokenWithUrl(connection.getToken());
         }
-        Token token = TokenHelper.getToken(connection.getClientInfo(), client);
-        connection.setToken(token);
-        Map<String, String> tokenMap = TokenHelper.getTokenWithUrl(token);
-        return tokenMap;
+        try {
+            Token token = TokenHelper.getToken(connection.getClientInfo(), client);
+            connection.setToken(token);
+            return TokenHelper.getTokenWithUrl(token);
+        } catch (TokenException e) {
+            throw new SQLException(e);
+        }
     }
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenException.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.salesforce.cdp.queryservice.util;
+
+/**
+ * Base exception for token related failures.
+ */
+public class TokenException extends Exception {
+
+    public TokenException(String msg) {
+        super(msg);
+    }
+
+    public TokenException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public TokenException(String msg, Throwable throwable) {
+        super(msg, throwable);
+    }
+}

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -39,6 +39,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static com.salesforce.cdp.queryservice.util.Messages.FAILED_LOGIN;
+import static com.salesforce.cdp.queryservice.util.Messages.RENEW_TOKEN;
 import static com.salesforce.cdp.queryservice.util.Messages.TOKEN_EXCHANGE_FAILURE;
 import static com.salesforce.cdp.queryservice.util.Messages.TOKEN_FETCH_FAILURE;
 
@@ -156,7 +158,7 @@ public class TokenHelper {
             return token;
         } catch (IOException e) {
             log.error("Caught exception while renewing the core token", e);
-            throw new TokenException(e);
+            throw new TokenException(RENEW_TOKEN, e);
         }
     }
 
@@ -216,7 +218,7 @@ public class TokenHelper {
             }
             return response;
         } catch (IOException e) {
-            throw new TokenException(e);
+            throw new TokenException(FAILED_LOGIN, e);
         }
     }
 

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
@@ -16,24 +16,26 @@
 
 package com.salesforce.cdp.queryservice.util;
 
+import com.google.common.collect.Sets;
 import com.salesforce.cdp.queryservice.interfaces.ExtendedHttpStatusCode;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class Utils {
 
     // NOTE: SC_UNPROCESSABLE_ENTITY added for retry due to bug W-9768558. Would be removed once this bug is fixed.
-    private static Set<Integer> retryStatusCodes = new HashSet<>(Arrays.asList(ExtendedHttpStatusCode.SC_TOO_MANY_REQUESTS,
+    private static final Set<Integer> retryStatusCodes = Collections.unmodifiableSet(Sets.newHashSet(
+            ExtendedHttpStatusCode.SC_TOO_MANY_REQUESTS,
             ExtendedHttpStatusCode.SC_MOVED_TEMPORARILY,
             ExtendedHttpStatusCode.SC_GATEWAY_TIMEOUT,
             ExtendedHttpStatusCode.SC_SERVICE_UNAVAILABLE,
             ExtendedHttpStatusCode.SC_UNPROCESSABLE_ENTITY,
             ExtendedHttpStatusCode.SC_UNAUTHORIZED,
             ExtendedHttpStatusCode.SC_INTERNAL_SERVER_ERROR,
-            ExtendedHttpStatusCode.SC_BAD_REQUEST));
+            ExtendedHttpStatusCode.SC_BAD_REQUEST
+    ));
 
     private Utils() {
         //NOOP
@@ -95,7 +97,7 @@ public class Utils {
         }
 
 
-        // Now allocate the new byte array to accomodate for the values, each encoded byte is 3 bytes now, but we already
+        // Now allocate the new byte array to accommodate for the values, each encoded byte is 3 bytes now, but we already
         // have one byte of the three for the original bytes, so we only need to allocate origlength + bytesNeedingReEncode * 2
         byte [] encoded = new byte[byteArray.length + (bytesNeedingReEncode * 2)];
 

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
@@ -23,9 +23,7 @@ import okhttp3.*;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -37,13 +35,12 @@ import java.sql.Types;
 import java.util.Properties;
 
 import static com.salesforce.cdp.queryservice.ResponseEnum.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryServiceMetadataTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Mock
     private QueryServiceConnection queryServiceConnection;
@@ -74,9 +71,11 @@ public class QueryServiceMetadataTest {
                 message("Unauthorized").
                 body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
         doReturn(response).when(queryExecutor).getMetadata();
-        exceptionRule.expect(SQLException.class);
-        exceptionRule.expectMessage("Internal Server Error");
-        queryServiceMetadata.getTables("", "", "", new String [0]);
+
+        Throwable ex = catchThrowableOfType(() -> {
+            queryServiceMetadata.getTables("", "", "", new String [0]);
+        }, SQLException.class);
+        assertThat(ex.getMessage()).contains("Failed to get the metadata. Please try again");
     }
 
     @Test
@@ -101,9 +100,11 @@ public class QueryServiceMetadataTest {
                 message("Not Found").
                 body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
         doReturn(response).when(queryExecutor).getMetadata();
-        exceptionRule.expect(SQLException.class);
-        exceptionRule.expectMessage(METADATA_EXCEPTION);
-        queryServiceMetadata.getColumns("", "", "", "");
+
+        Throwable ex = catchThrowableOfType(() -> {
+            queryServiceMetadata.getColumns("", "", "", "");
+        }, SQLException.class);
+        assertThat(ex.getMessage()).contains(METADATA_EXCEPTION);
     }
 
     @Test

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceStatementTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceStatementTest.java
@@ -22,12 +22,12 @@ import com.salesforce.cdp.queryservice.util.QueryExecutor;
 import com.salesforce.cdp.queryservice.ResponseEnum;
 import okhttp3.*;
 import org.apache.http.HttpStatus;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import static org.junit.Assert.assertThat;
+
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -45,9 +45,6 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryServiceStatementTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Mock
     private QueryServiceConnection queryServiceConnection;
@@ -76,9 +73,12 @@ public class QueryServiceStatementTest {
                 message("Unauthorized").
                 body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
         doReturn(response).when(queryExecutor).executeQuery(anyString(), any(Optional.class), any(Optional.class), any(Optional.class));
-        exceptionRule.expect(SQLException.class);
-        exceptionRule.expectMessage("Authorization header verification failed");
-        queryServiceStatement.executeQuery("select FirstName__c from Individual__dlm limit 10");
+
+        Throwable ex = catchThrowableOfType(() -> {
+            queryServiceStatement.executeQuery("select FirstName__c from Individual__dlm limit 10");
+        }, SQLException.class);
+        Assertions.assertThat(ex.getCause()).isInstanceOf(IOException.class);
+        Assertions.assertThat(ex.getCause().getMessage()).contains("Authorization header verification failed");
     }
 
     @Test
@@ -116,9 +116,10 @@ public class QueryServiceStatementTest {
     @Test
     public void testExceuteQueryWithIOException() throws IOException, SQLException {
         doThrow(new IOException("IO Exception")).when(queryExecutor).executeQuery(anyString(), any(Optional.class), any(Optional.class), any(Optional.class));
-        exceptionRule.expect(SQLException.class);
-        exceptionRule.expectMessage(QUERY_EXCEPTION);
-        queryServiceStatement.executeQuery("select FirstName__c from Individual__dlm limit 10");
+        Throwable ex = catchThrowableOfType(() -> {
+            queryServiceStatement.executeQuery("select FirstName__c from Individual__dlm limit 10");
+        }, SQLException.class);
+        Assertions.assertThat(ex.getMessage()).contains(QUERY_EXCEPTION);
     }
 
     @Test

--- a/src/test/java/com/salesforce/cdp/queryservice/util/QueryExecutorTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/util/QueryExecutorTest.java
@@ -50,7 +50,7 @@ public class QueryExecutorTest {
     private QueryServiceConnection connection;
 
     @Before
-    public void init() throws SQLException {
+    public void init() throws Exception {
         Properties properties = new Properties();
         properties.put(Constants.BASE_URL, "https://mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com");
         properties.put(Constants.CORETOKEN, "Test_Token");

--- a/src/test/java/com/salesforce/cdp/queryservice/util/TokenHelperTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/util/TokenHelperTest.java
@@ -151,7 +151,7 @@ public class TokenHelperTest {
             TokenHelper.getToken(properties, client);
         }, TokenException.class);
         assertThat(ex.getCause()).isInstanceOf(IOException.class);
-        assertThat(ex.getMessage()).contains("expired authorization code");
+        assertThat(ex.getCause().getMessage()).contains("expired authorization code");
     }
 
     @Test


### PR DESCRIPTION
### Changes

* Add retry interceptor for Query execution related failures
* Add full retry for Token exchange failures
* Introduce new TokenException
    * Instead of SQLException, TokenException would be thrown/returned by TokenHelper
* Use separate clients for token exchange and query execution (both share base client so resources would be shared)
* Add support to pass maxRetries as client property, defaults to 3
* Segregate error messages by case

### Questions
* TokenHelper throws TokenException, previously it threw SQLException. So, it would be breaking sort of change. There are 2 ways to handle it or is this change acceptable? As this is internal logic, would it be okay with this change or should we be more conservative?
    * Deprecate TokenHelper and introduce TokenProvider
    * wrap all exceptions and emit SQLException from `getToken` 
* Should we expose maxRetries to users?
* Uses FailSafe library for retries (Apache license should be good). Should we include additional library or just have simple retry mechanism?

> NOTE: I have left some `fixme`, `todo` comments for future changes