### PR TITLE
Fail connection creation on invalid credentials

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.salesforce.cdp.queryservice.model.Token;
 import com.salesforce.cdp.queryservice.util.Constants;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.sql.*;
@@ -44,6 +43,9 @@ public class QueryServiceConnection implements Connection {
         this.properties.put(Constants.LOGIN_URL, serviceRootUrl);
         addClientSecretsIfRequired(serviceRootUrl, this.properties);
         this.enableArrowStream = Boolean.parseBoolean(this.properties.getProperty(Constants.ENABLE_ARROW_STREAM));
+
+        // use isValid to test connection
+        this.isValid(20);
     }
 
     /**
@@ -316,7 +318,13 @@ public class QueryServiceConnection implements Connection {
 
     @Override
     public boolean isValid(int timeout) throws SQLException {
-        return BooleanUtils.isFalse(isClosed());
+        if (isClosed()) {
+            return false;
+        }
+        // todo: if there is any other cheaper to check if connection is valid
+        QueryServiceMetadata serviceMetadata = (QueryServiceMetadata) getMetaData();
+        serviceMetadata.getMetadataResponse();
+        return true;
     }
 
     @Override
@@ -387,6 +395,7 @@ public class QueryServiceConnection implements Connection {
     }
 
     private void cleanup() {
+        // todo: shoudn't cleanup also clear/reset properties?
         token = null;
     }
 

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Slf4j
 public class QueryServiceConnection implements Connection {
 
+    private static final String TEST_CONNECT_QUERY = "select 1";
+
     private AtomicBoolean closed = new AtomicBoolean(false);
     private Properties properties;
     private final String serviceRootUrl;
@@ -321,10 +323,9 @@ public class QueryServiceConnection implements Connection {
         if (isClosed()) {
             return false;
         }
-        // todo: if there is any other cheaper to check if connection is valid
-        QueryServiceMetadata serviceMetadata = (QueryServiceMetadata) getMetaData();
-        serviceMetadata.getMetadataResponse();
-        return true;
+        try (PreparedStatement statement = this.prepareStatement(TEST_CONNECT_QUERY)) {
+            return statement.execute();
+        }
     }
 
     @Override

--- a/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
@@ -83,7 +83,7 @@ public class QueryExecutor {
         // fixme: preferably, avoid using optional as parameter type, instead specify nullable value
         log.info("Preparing to execute query {}", sql);
         AnsiQueryRequest ansiQueryRequest = AnsiQueryRequest.builder().sql(sql).build();
-        RequestBody body = RequestBody.create(MediaType.parse(Constants.JSON_CONTENT), new Gson().toJson(ansiQueryRequest));
+        RequestBody body = RequestBody.create(new Gson().toJson(ansiQueryRequest), MediaType.parse(Constants.JSON_CONTENT));
         Map<String, String> tokenWithTenantUrl = getTokenWithTenantUrl();
         StringBuilder url = new StringBuilder(Constants.PROTOCOL)
                 .append(tokenWithTenantUrl.get(Constants.TENANT_URL))

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceConnectionTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceConnectionTest.java
@@ -16,7 +16,6 @@
 
 package com.salesforce.cdp.queryservice.core;
 
-import com.salesforce.cdp.queryservice.model.MetadataResponse;
 import com.salesforce.cdp.queryservice.util.Constants;
 import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +31,7 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
@@ -153,13 +153,13 @@ public class QueryServiceConnectionTest {
 
         QueryServiceConnection connection = spy(new QueryServiceConnection(serverUrl, properties));
         doCallRealMethod().when(connection).isValid(anyInt());
-        QueryServiceMetadata metadata = mock(QueryServiceMetadata.class);
-        doReturn(metadata).when(connection).getMetaData();
-        doReturn(new MetadataResponse()).when(metadata).getMetadataResponse();
+        QueryServicePreparedStatement preparedStatement = mock(QueryServicePreparedStatement.class);
+        doReturn(preparedStatement).when(connection).prepareStatement(anyString());
+        doReturn(true).when(preparedStatement).execute();
 
         assertThat(connection.isValid(10)).isTrue();
 
-        doThrow(new SQLException()).when(metadata).getMetadataResponse();
+        doThrow(new SQLException()).when(preparedStatement).execute();
         Throwable ex = catchThrowableOfType(() -> {
             connection.isValid(10);
         }, SQLException.class);


### PR DESCRIPTION
This change ensures the test connection flow is similar to other JDBC connector. During connection creation, check if credentials are valid or not. Also, complete `isValid` flow.

In future, find much cheaper way to validate the connection.

This includes changes from PR #46. Once the other PR is merged, will rebase and update this PR