### PR TITLE
Ignore PowerMock reflection error

### DIFF
--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceConnectionTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceConnectionTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.runner.RunWith;
 import org.powermock.api.support.membermodification.MemberMatcher;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -43,6 +44,7 @@ import static org.powermock.api.support.membermodification.MemberModifier.suppre
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({QueryServiceConnection.class})
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class QueryServiceConnectionTest {
 
     @Test


### PR DESCRIPTION
This ensures that source can be built with java 11