### PR TITLE
Add logs whenever retry is done for token failure

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/QueryExecutor.java
@@ -150,6 +150,8 @@ public class QueryExecutor {
         //  check if delay or backoff need to introduced b/w each retry
         RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
                 .handle(TokenException.class)
+                .onRetry(e -> log.warn("Failure #{}. Retrying.", e.getAttemptCount()))
+                .onRetriesExceeded(e -> log.warn("Failed to connect. Max retries exceeded."))
                 .withMaxRetries(getMaxRetries(connection.getClientInfo()));
         try {
             // failsafe executes the given block and returns the results


### PR DESCRIPTION
https://failsafe.dev/retry/#event-listeners

sample logs (selected)
```log
[Thread-0] WARN com.salesforce.cdp.queryservice.util.QueryExecutor - Failed to connect. Max retries exceeded.
[Thread-1] WARN com.salesforce.cdp.queryservice.util.QueryExecutor - Failure #1. Retrying.
```