### PR TITLE
Update tokenHelper to allow for wider range of test orgs

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -37,8 +37,8 @@ public class Constants {
 
     // Common server information
     public static final String PROD_SERVER_URL = ".salesforce.com";
-    public static final String NA45_SERVER_URL = "na45.test1.pc-rnd.salesforce.com";
-    public static final String NA46_SERVER_URL = "na46.test1.pc-rnd.salesforce.com";
+    public static final String TEST_SERVER_URL = "test1.pc-rnd.salesforce.com";
+
 
     //Audience constants for different environments
     public static final String PROD_SERVER_AUD = "login.salesforce.com";

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -190,7 +190,7 @@ public class TokenHelper {
 
     private static String getAudienceForJWTAssertion(String serviceRootUrl) throws SQLException {
         String serverUrl = serviceRootUrl.toLowerCase();
-        if (serverUrl.endsWith(Constants.NA45_SERVER_URL) || serverUrl.endsWith(Constants.NA46_SERVER_URL)) {
+        if (serverUrl.contains(Constants.TEST_SERVER_URL)) {
             return Constants.DEV_TEST_SERVER_AUD;
         } else if (serverUrl.endsWith(Constants.PROD_SERVER_URL)) {
             return Constants.PROD_SERVER_AUD;


### PR DESCRIPTION
This JDBC driver cannot currently be used for some orgfarm orgs since they didn't match the string criteria. This update should allow all test orgs to use the correct audience and login correctly.