### PR TITLE
Refresh token when core token is invalid but refresh token is valid

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -245,7 +245,7 @@ public class TokenHelper {
         try{
             return exchangeToken(url,coreToken,dataspace,client);
         } catch (TokenException e) {
-            log.error("Core token is not valid fetching a new token ");
+            log.error("Core token is not valid fetching a new token ", e);
             return renewToken(url,refreshToken,clientId,secret,dataspace,client);
         }
     }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -87,7 +87,10 @@ public class TokenHelper {
                     && properties.containsKey(Constants.PRIVATE_KEY)) {
                 return retrieveTokenWithJWTBearerGrant(properties, client);
             }
-            Token newToken = exchangeToken(properties.getProperty(Constants.LOGIN_URL), properties.getProperty(Constants.CORETOKEN), properties.getProperty(Constants.DATASPACE),client);
+            Token newToken = exchangeTokenWithRefresh(properties.getProperty(Constants.LOGIN_URL),
+                    properties.getProperty(Constants.REFRESHTOKEN),properties.getProperty(Constants.CORETOKEN)
+                    , properties.getProperty(Constants.CLIENT_ID),properties.getProperty(Constants.CLIENT_SECRET),properties.getProperty(Constants.DATASPACE),
+                    client);
             tokenCache.put(properties.getProperty(Constants.CORETOKEN), newToken);
             return newToken;
         }
@@ -234,6 +237,17 @@ public class TokenHelper {
             throw new TokenException(RENEW_TOKEN, e);
         }
         return coreTokenRenewResponse;
+    }
+
+    private static Token exchangeTokenWithRefresh(String url, String refreshToken,
+                                                  String coreToken, String clientId, String secret,
+                                                  String dataspace,OkHttpClient client) throws TokenException {
+        try{
+            return exchangeToken(url,coreToken,dataspace,client);
+        } catch (TokenException e) {
+            log.error("Core token is not valid fetching a new token ");
+            return renewToken(url,refreshToken,clientId,secret,dataspace,client);
+        }
     }
 
     private static Token exchangeToken(String url, String coreToken,String dataspace, OkHttpClient client) throws TokenException {


### PR DESCRIPTION
Get a new Access token and exchange token if valid refresh token is provided. This helps in the case of using the driver in spark , where connections are made from multiple machines.