### PR TITLE
Filter slf4j from shaded/uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,13 @@
                                 <exclude>codegen/**</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>org.slf4j:slf4j-simple</artifact>
+                            <excludes>
+                                <!-- Causes logging binding warnings with other java projects that use the shaded jar -->
+                                <exclude>org/slf4j/**</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                     <transformers>
                         <transformer


### PR DESCRIPTION
Without SLF4J filtered, other java projects that attempt to use the uber jar will receive logging binding errors. This fixes that