### PR TITLE
getSchemas should return dataspaces for all clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.queryService</groupId>
     <artifactId>Salesforce-CDP-jdbc</artifactId>
-    <version>1.19.2</version>
+    <version>1.19.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -668,11 +668,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas() throws SQLException {
-        if(isTableauClient() || isDataWranglerClient()){
-            return getDataSpaces();
-        }
-        return new QueryServiceResultSet(Collections.EMPTY_LIST,
-                new QueryServiceResultSetMetaData(GET_SCHEMAS));
+        return getDataSpaces();
     }
 
     private QueryServiceResultSet getDataSpaces() throws SQLException {
@@ -702,16 +698,6 @@ public class QueryServiceMetadata implements DatabaseMetaData {
         row.put("TABLE_CAT", Constants.CATALOG);
         row.put("TABLE_SCHEM", dataspaceName);
         return row;
-    }
-
-    private boolean isTableauClient() {
-        String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
-        return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.TABLEAU_USER_AGENT_VALUE);
-    }
-
-    private boolean isDataWranglerClient() {
-        String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
-        return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.DATA_WRANGLER_USER_AGENT_VALUE);
     }
 
     @Override
@@ -967,11 +953,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        if(isTableauClient() || isDataWranglerClient()){
-            return getDataSpaces();
-        }
-        return new QueryServiceResultSet(Collections.EMPTY_LIST,
-                new QueryServiceResultSetMetaData(GET_SCHEMAS));
+        return getDataSpaces();
     }
 
     @Override

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -59,7 +59,6 @@ public class Constants {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String USER_AGENT_VALUE = "cdp/jdbc";
     public static final String TABLEAU_USER_AGENT_VALUE = "Tableau/Audiences360";
-    public static final String DATA_WRANGLER_USER_AGENT_VALUE = "Data-Wrangler";
     public static final String JSON_CONTENT = "application/json";
     public static final String URL_ENCODED_CONTENT = "application/x-www-form-urlencoded";
     public static final String ENABLE_ARROW_STREAM = "enable-arrow-stream";

--- a/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
@@ -282,7 +282,27 @@ public enum ResponseEnum {
             "</head>\n" +
             "\n" +
             "\n" +
-            "</html>");
+            "</html>"),
+    DATASPACE_RESPONSE("{\n" +
+            "    \"totalSize\": 2,\n" +
+            "    \"done\": true,\n" +
+            "    \"records\": [\n" +
+            "        {\n" +
+            "            \"attributes\": {\n" +
+            "                \"type\": \"DataSpace\",\n" +
+            "                \"url\": \"/services/data/v60.0/sobjects/DataSpace/0vhVF00000003AnYAI\"\n" +
+            "            },\n" +
+            "            \"Name\": \"default\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "            \"attributes\": {\n" +
+            "                \"type\": \"DataSpace\",\n" +
+            "                \"url\": \"/services/data/v60.0/sobjects/DataSpace/0vhVF0000000Ch7YAE\"\n" +
+            "            },\n" +
+            "            \"Name\": \"DS2\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}");
 
     private String response;
 

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Properties;
 
 import static com.salesforce.cdp.queryservice.ResponseEnum.*;
@@ -134,6 +136,40 @@ public class QueryServiceMetadataTest {
         doReturn(response).when(queryExecutor).getMetadata();
         ResultSet resultSet = queryServiceMetadata.getColumns("", "", "Individual__dlm", "");
         Assert.assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testGetSchemas() throws SQLException {
+        String jsonString = DATASPACE_RESPONSE.getResponse();
+        Response response = new Response.Builder().code(HttpStatus.SC_OK).
+                request(buildRequest()).protocol(Protocol.HTTP_1_1).
+                message("Successful").
+                body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
+        doReturn(response).when(queryExecutor).getDataspaces();
+        ResultSet resultSet = queryServiceMetadata.getSchemas();
+        List<Object> results = ((QueryServiceResultSet) resultSet).data;
+        Assert.assertEquals(results.size(), 2);
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_SCHEM"), "default");
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_CAT"), "catalog");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_SCHEM"), "DS2");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_CAT"), "catalog");
+    }
+
+    @Test
+    public void testGetSchemasWithCatalogAndSchemaPattern() throws SQLException {
+        String jsonString = DATASPACE_RESPONSE.getResponse();
+        Response response = new Response.Builder().code(HttpStatus.SC_OK).
+                request(buildRequest()).protocol(Protocol.HTTP_1_1).
+                message("Successful").
+                body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
+        doReturn(response).when(queryExecutor).getDataspaces();
+        ResultSet resultSet = queryServiceMetadata.getSchemas("random_catalog", "random_pattern");
+        List<Object> results = ((QueryServiceResultSet) resultSet).data;
+        Assert.assertEquals(results.size(), 2);
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_SCHEM"), "default");
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_CAT"), "catalog");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_SCHEM"), "DS2");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_CAT"), "catalog");
     }
 
 


### PR DESCRIPTION
Earlier only for tableau and data wrangler we returned list of dataspaces as part of `getSchemas`. Now more clients are demanding this, so changing it for all.