### PR TITLE
Boolean support and getSchemas changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ This flow utilizes Salesforce's server to server [JWT bearer flow](https://help.
    1. Select **“Edit Policies”**
    2. Change **“IP Relaxation”** to **“Relax IP restrictions”**
    3. Select **Save**
+5. In Setup search for **"OAuth and OpenID Connect Settings"**
+   1. Turn on **"Allow OAuth Username-Password Flows"**
+
 
 ## App Authorization
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.queryService</groupId>
     <artifactId>Salesforce-CDP-jdbc</artifactId>
-    <version>1.19.3</version>
+    <version>1.19.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -18,6 +18,8 @@
         <lombok.version>1.18.22</lombok.version>
         <slf4j.version>1.7.32</slf4j.version>
         <shadeBase>com.salesforce.cdp.queryservice.internal</shadeBase>
+        <maven.compiler.source>{java.version}</maven.compiler.source>
+        <maven.compiler.target>{java.version}</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.queryService</groupId>
     <artifactId>Salesforce-CDP-jdbc</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.queryService</groupId>
     <artifactId>Salesforce-CDP-jdbc</artifactId>
-    <version>1.19.2</version>
+    <version>1.19.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/salesforce/cdp/queryservice/core/JavaType.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/JavaType.java
@@ -27,7 +27,9 @@ public enum JavaType implements SQLType {
 
     DATE(Types.DATE, "DATE"),
 
-    NUMBER(Types.NUMERIC, "NUMBER");
+    NUMBER(Types.NUMERIC, "NUMBER"),
+
+    BOOLEAN(Types.BOOLEAN, "BOOLEAN");
 
     private Integer type;
 

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -668,7 +668,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas() throws SQLException {
-        if(isTableauClient()){
+        if(isTableauClient() || isDataWranglerClient()){
             return getDataSpaces();
         }
         return new QueryServiceResultSet(Collections.EMPTY_LIST,
@@ -707,6 +707,11 @@ public class QueryServiceMetadata implements DatabaseMetaData {
     private boolean isTableauClient() {
         String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
         return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.TABLEAU_USER_AGENT_VALUE);
+    }
+
+    private boolean isDataWranglerClient() {
+        String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
+        return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.DATA_WRANGLER_USER_AGENT_VALUE);
     }
 
     @Override
@@ -962,7 +967,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        if(isTableauClient()){
+        if(isTableauClient() || isDataWranglerClient()){
             return getDataSpaces();
         }
         return new QueryServiceResultSet(Collections.EMPTY_LIST,

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -668,11 +668,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas() throws SQLException {
-        if(isTableauClient() || isDataWranglerClient()){
-            return getDataSpaces();
-        }
-        return new QueryServiceResultSet(Collections.EMPTY_LIST,
-                new QueryServiceResultSetMetaData(GET_SCHEMAS));
+        return getDataSpaces();
     }
 
     private QueryServiceResultSet getDataSpaces() throws SQLException {
@@ -702,16 +698,6 @@ public class QueryServiceMetadata implements DatabaseMetaData {
         row.put("TABLE_CAT", Constants.CATALOG);
         row.put("TABLE_SCHEM", dataspaceName);
         return row;
-    }
-
-    private boolean isTableauClient() {
-        String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
-        return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.TABLEAU_USER_AGENT_VALUE);
-    }
-
-    private boolean isDataWranglerClient() {
-        String userAgent =String.valueOf(properties.get(Constants.USER_AGENT));
-        return StringUtils.isNotBlank(userAgent) && userAgent.equals(Constants.DATA_WRANGLER_USER_AGENT_VALUE);
     }
 
     @Override
@@ -967,11 +953,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
 
     @Override
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        if(isTableauClient() || isDataWranglerClient()){
-            return getDataSpaces();
-        }
-        return new QueryServiceResultSet(Collections.EMPTY_LIST,
-                new QueryServiceResultSetMetaData(GET_SCHEMAS));
+        return getDataSpaces();
     }
 
     @Override

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -59,6 +59,7 @@ public class Constants {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String USER_AGENT_VALUE = "cdp/jdbc";
     public static final String TABLEAU_USER_AGENT_VALUE = "Tableau/Audiences360";
+    public static final String DATA_WRANGLER_USER_AGENT_VALUE = "Data-Wrangler";
     public static final String JSON_CONTENT = "application/json";
     public static final String URL_ENCODED_CONTENT = "application/x-www-form-urlencoded";
     public static final String ENABLE_ARROW_STREAM = "enable-arrow-stream";

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -59,7 +59,6 @@ public class Constants {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String USER_AGENT_VALUE = "cdp/jdbc";
     public static final String TABLEAU_USER_AGENT_VALUE = "Tableau/Audiences360";
-    public static final String DATA_WRANGLER_USER_AGENT_VALUE = "Data-Wrangler";
     public static final String JSON_CONTENT = "application/json";
     public static final String URL_ENCODED_CONTENT = "application/x-www-form-urlencoded";
     public static final String ENABLE_ARROW_STREAM = "enable-arrow-stream";

--- a/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
@@ -54,6 +54,10 @@ public enum ResponseEnum {
             "                    \"type\": \"STRING\"\n" +
             "                },\n" +
             "                {\n" +
+            "                    \"name\": \"active__c\",\n" +
+            "                    \"type\": \"BOOLEAN\"\n" +
+            "                },\n" +
+            "                {\n" +
             "                    \"name\": \"PartyId__c\",\n" +
             "                    \"type\": \"STRING\"\n" +
             "                }\n" +
@@ -250,12 +254,12 @@ public enum ResponseEnum {
             "    \"queryId\": \"53c66a0f-e666-4f61-9f84-7718528b7a63\",\n" +
             "    \"done\": true,\n" +
             "    \"metadata\": {\n" +
-                    "        \"count_num\": {\n" +
-                    "            \"placeInOrder\": 0,\n" +
-                    "            \"typeCode\": 3,\n" +
-                    "            \"type\": \"DECIMAL\"\n" +
-                    "        }\n" +
-                    "} \n" +
+            "        \"count_num\": {\n" +
+            "            \"placeInOrder\": 0,\n" +
+            "            \"typeCode\": 3,\n" +
+            "            \"type\": \"DECIMAL\"\n" +
+            "        }\n" +
+            "} \n" +
             "}"),
     HTML_ERROR_RESPONSE("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
             "<html>\n" +

--- a/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/ResponseEnum.java
@@ -282,7 +282,27 @@ public enum ResponseEnum {
             "</head>\n" +
             "\n" +
             "\n" +
-            "</html>");
+            "</html>"),
+    DATASPACE_RESPONSE("{\n" +
+            "    \"totalSize\": 2,\n" +
+            "    \"done\": true,\n" +
+            "    \"records\": [\n" +
+            "        {\n" +
+            "            \"attributes\": {\n" +
+            "                \"type\": \"DataSpace\",\n" +
+            "                \"url\": \"/services/data/v60.0/sobjects/DataSpace/0vhVF00000003AnYAI\"\n" +
+            "            },\n" +
+            "            \"Name\": \"default\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "            \"attributes\": {\n" +
+            "                \"type\": \"DataSpace\",\n" +
+            "                \"url\": \"/services/data/v60.0/sobjects/DataSpace/0vhVF0000000Ch7YAE\"\n" +
+            "            },\n" +
+            "            \"Name\": \"DS2\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}");
 
     private String response;
 

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
@@ -52,6 +53,8 @@ public class QueryServiceMetadataTest {
 
     private QueryServiceMetadata queryServiceMetadata;
 
+    private List<String> booleanColumns = new ArrayList<>();
+
     @Before
     public void init() {
         Properties properties = new Properties();
@@ -63,6 +66,7 @@ public class QueryServiceMetadataTest {
                 return queryExecutor;
             }
         };
+        booleanColumns.add("active__c");
     }
 
     @Test
@@ -119,9 +123,15 @@ public class QueryServiceMetadataTest {
         doReturn(response).when(queryExecutor).getMetadata();
         ResultSet resultSet = queryServiceMetadata.getColumns("", "", "ContactPointEmail__dlm", "");
         while(resultSet.next()) {
-            Assert.assertNotNull(resultSet.getString("COLUMN_NAME"));
-            Assert.assertEquals(resultSet.getInt("DATA_TYPE"), Types.VARCHAR);
-            Assert.assertEquals(resultSet.getString("SQL_DATA_TYPE"), JavaType.STRING.getName());
+            String columnName = resultSet.getString("COLUMN_NAME");
+            Assert.assertNotNull(columnName);
+            if (booleanColumns.contains(columnName)) {
+                Assert.assertEquals(resultSet.getInt("DATA_TYPE"), Types.BOOLEAN);
+                Assert.assertEquals(resultSet.getString("SQL_DATA_TYPE"), JavaType.BOOLEAN.getName());
+            } else {
+                Assert.assertEquals(resultSet.getInt("DATA_TYPE"), Types.VARCHAR);
+                Assert.assertEquals(resultSet.getString("SQL_DATA_TYPE"), JavaType.STRING.getName());
+            }
         }
         Assert.assertEquals(resultSet.getMetaData().getColumnCount(), 24);
     }

--- a/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadataTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Properties;
 
 import static com.salesforce.cdp.queryservice.ResponseEnum.*;
@@ -134,6 +136,40 @@ public class QueryServiceMetadataTest {
         doReturn(response).when(queryExecutor).getMetadata();
         ResultSet resultSet = queryServiceMetadata.getColumns("", "", "Individual__dlm", "");
         Assert.assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testGetSchemas() throws SQLException {
+        String jsonString = DATASPACE_RESPONSE.getResponse();
+        Response response = new Response.Builder().code(HttpStatus.SC_OK).
+                request(buildRequest()).protocol(Protocol.HTTP_1_1).
+                message("Successful").
+                body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
+        doReturn(response).when(queryExecutor).getDataspaces();
+        ResultSet resultSet = queryServiceMetadata.getSchemas();
+        List<Object> results = ((QueryServiceResultSet) resultSet).data;
+        Assert.assertEquals(results.size(), 2);
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_SCHEM"), "default");
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_CAT"), "catalog");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_SCHEM"), "DS2");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_CAT"), "catalog");
+    }
+
+    @Test
+    public void testGetSchemasWithCatalogAndSchemaPattern() throws SQLException {
+        String jsonString = DATASPACE_RESPONSE.getResponse();
+        Response response = new Response.Builder().code(HttpStatus.SC_OK).
+                request(buildRequest()).protocol(Protocol.HTTP_1_1).
+                message("Successful").
+                body(ResponseBody.create(jsonString, MediaType.parse("application/json"))).build();
+        doReturn(response).when(queryExecutor).getDataspaces();
+        ResultSet resultSet = queryServiceMetadata.getSchemas("random_catalog", "random_pattern");
+        List<Object> results = ((QueryServiceResultSet) resultSet).data;
+        Assert.assertEquals(results.size(), 2);
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_SCHEM"), "default");
+        Assert.assertEquals(((LinkedHashMap) results.get(0)).get("TABLE_CAT"), "catalog");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_SCHEM"), "DS2");
+        Assert.assertEquals(((LinkedHashMap) results.get(1)).get("TABLE_CAT"), "catalog");
     }
 
 


### PR DESCRIPTION
- Add support for boolean type
- getSchemas now returns list of dataspaces for all clients. Earlier this support was available only for Tableau and Data Wrangler