### PR TITLE
@W-16008197: Fix for caching the metadata across connections

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/auth/TokenExchangeHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/auth/TokenExchangeHelper.java
@@ -52,7 +52,7 @@ public class TokenExchangeHelper {
         Response response = null;
         try {
             response = login(requestBody, token_url);
-            OffcoreToken token = HttpHelper.handleSuccessResponse(response, OffcoreToken.class, false);
+            OffcoreToken token = HttpHelper.handleSuccessResponse(response, OffcoreToken.class);
             if (token.getErrorDescription() != null) {
                 log.error("Token exchange failed with error {}", token.getErrorDescription());
                 TokenUtils.invalidateCoreToken(url, coreToken, client);

--- a/src/main/java/com/salesforce/cdp/queryservice/auth/jwt/JwtLoginClient.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/auth/jwt/JwtLoginClient.java
@@ -58,7 +58,7 @@ public class JwtLoginClient {
                 log.error("login with user credentials failed with status code {}", response.code());
                 HttpHelper.handleErrorResponse(response, Constants.ERROR_DESCRIPTION);
             }
-            return HttpHelper.handleSuccessResponse(response, CoreToken.class, false);
+            return HttpHelper.handleSuccessResponse(response, CoreToken.class);
         } catch (IOException e) {
             log.error("login with user credentials failed", e);
             throw new TokenException(FAILED_LOGIN, e);

--- a/src/main/java/com/salesforce/cdp/queryservice/auth/refresh/RefreshTokenClient.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/auth/refresh/RefreshTokenClient.java
@@ -37,7 +37,7 @@ public class RefreshTokenClient {
         requestBody.put(Constants.REFRESH_TOKEN_GRANT_TYPE, refreshToken);
         try {
             Response response = login(requestBody, token_url);
-            return HttpHelper.handleSuccessResponse(response, CoreToken.class, false);
+            return HttpHelper.handleSuccessResponse(response, CoreToken.class);
         }
         catch (IOException e) {
             log.error("Caught exception while renewing the core token", e);

--- a/src/main/java/com/salesforce/cdp/queryservice/auth/unpwd/UnPwdAuthClient.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/auth/unpwd/UnPwdAuthClient.java
@@ -59,7 +59,7 @@ public class UnPwdAuthClient {
                 log.error("login with user credentials failed with status code {}", response.code());
                 HttpHelper.handleErrorResponse(response, Constants.ERROR_DESCRIPTION);
             }
-            return HttpHelper.handleSuccessResponse(response, CoreToken.class, false);
+            return HttpHelper.handleSuccessResponse(response, CoreToken.class);
         } catch (IOException e) {
             log.error("login with user credentials failed", e);
             throw new TokenException(FAILED_LOGIN, e);

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceAbstractStatement.java
@@ -99,7 +99,7 @@ public abstract class QueryServiceAbstractStatement {
                     log.error("Request query {} failed with response code {} and trace-Id {}", sql, response.code(), response.headers().get(Constants.TRACE_ID));
                     HttpHelper.handleErrorResponse(response, Constants.MESSAGE);
                 }
-                QueryServiceResponse queryServiceResponse = HttpHelper.handleSuccessResponse(response, QueryServiceResponse.class, false);
+                QueryServiceResponse queryServiceResponse = HttpHelper.handleSuccessResponse(response, QueryServiceResponse.class);
                 return createResultSetFromResponse(queryServiceResponse, isCursorBasedPaginationReq);
             }
         } catch (IOException e) {
@@ -115,7 +115,7 @@ public abstract class QueryServiceAbstractStatement {
                 log.error("Request query {} failed with response code {} and trace-Id {}", sql, response.code(), response.headers().get(Constants.TRACE_ID));
                 HttpHelper.handleErrorResponse(response, Constants.MESSAGE);
             }
-            QueryServiceResponse queryServiceResponse = HttpHelper.handleSuccessResponse(response, QueryServiceResponse.class, false);
+            QueryServiceResponse queryServiceResponse = HttpHelper.handleSuccessResponse(response, QueryServiceResponse.class);
             return createResultSetFromResponse(queryServiceResponse, true);
         } catch (IOException e) {
             log.error("Exception while running the query", e);

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceConnection.java
@@ -460,7 +460,7 @@ public class QueryServiceConnection implements Connection {
             QueryExecutor executor = createQueryExecutor();
             Response response = executor.getQueryConfig();
 
-            return HttpHelper.handleSuccessResponse(response, QueryConfigResponse.class, false);
+            return HttpHelper.handleSuccessResponse(response, QueryConfigResponse.class);
         } catch (IOException e) {
             log.error("Exception while getting config from query service", e);
             throw new SQLException(QUERY_CONFIG_ERROR, e);

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -729,7 +729,12 @@ public class QueryServiceMetadata implements DatabaseMetaData {
                         response.code(), response.headers().get(Constants.TRACE_ID));
                 HttpHelper.handleErrorResponse(response, Constants.MESSAGE);
             }
-            return HttpHelper.handleSuccessResponse(response, MetadataResponse.class, true);
+            StringBuilder cacheKey = new StringBuilder(response.request().url().toString());
+            if(StringUtils.isNotBlank(queryServiceConnection.getDataspace())) {
+                cacheKey.append(":").append(queryServiceConnection.getDataspace());
+            }
+
+            return HttpHelper.handleSuccessResponseWithCache(response, MetadataResponse.class, cacheKey.toString());
         } catch (IOException e) {
             log.error("Exception while getting metadata from query service", e);
             throw new SQLException(METADATA_EXCEPTION, e);

--- a/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/core/QueryServiceMetadata.java
@@ -22,26 +22,38 @@ import com.salesforce.cdp.queryservice.model.MetadataResponse;
 import com.salesforce.cdp.queryservice.model.TableMetadata;
 import com.salesforce.cdp.queryservice.util.Constants;
 import com.salesforce.cdp.queryservice.util.HttpHelper;
-import static com.salesforce.cdp.queryservice.util.Messages.METADATA_EXCEPTION;
-
-import com.salesforce.cdp.queryservice.util.MetadataCacheUtil;
 import com.salesforce.cdp.queryservice.util.QueryExecutor;
 import com.salesforce.cdp.queryservice.util.Utils;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.MediaType;
-import okhttp3.Protocol;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpStatus;
 
 import java.io.IOException;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Pattern;
 
-import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.*;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.EMPTY;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_CATALOGS;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_COLUMNS;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_PRIMARY_KEYS;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_SCHEMAS;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_TABLES;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_TABLE_PRIVILEGES;
+import static com.salesforce.cdp.queryservice.core.QueryServiceDbMetadata.GET_TABLE_TYPES;
+import static com.salesforce.cdp.queryservice.util.Messages.METADATA_EXCEPTION;
 
 @Slf4j
 public class QueryServiceMetadata implements DatabaseMetaData {
@@ -735,7 +747,7 @@ public class QueryServiceMetadata implements DatabaseMetaData {
                         response.code(), response.headers().get(Constants.TRACE_ID));
                 HttpHelper.handleErrorResponse(response, Constants.MESSAGE);
             }
-            return HttpHelper.handleSuccessResponseWithCache(response, MetadataResponse.class, queryServiceConnection);
+            return HttpHelper.handleSuccessResponse(response, MetadataResponse.class);
         } catch (IOException e) {
             log.error("Exception while getting metadata from query service", e);
             throw new SQLException(METADATA_EXCEPTION, e);

--- a/src/main/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptor.java
@@ -16,10 +16,15 @@
 
 package com.salesforce.cdp.queryservice.interceptors;
 
+import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
 import com.salesforce.cdp.queryservice.util.Constants;
-import com.salesforce.cdp.queryservice.util.MetadataCacheUtil;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.*;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -27,13 +32,18 @@ import java.io.IOException;
 
 @Slf4j
 public class MetadataCacheInterceptor implements Interceptor {
+    private final QueryServiceConnection connection;
+
+    public MetadataCacheInterceptor(QueryServiceConnection connection) {
+        this.connection = connection;
+    }
 
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
         Request request = chain.request();
+        String responseString = connection.getMetadataFromCacheIfPresent();
         Response response;
-        String responseString = MetadataCacheUtil.getMetadata(request.url().toString());
         if (responseString != null) {
             log.trace("Getting the metadata response from local cache");
             response = new Response.Builder().code(HttpStatus.SC_OK).

--- a/src/main/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptor.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptor.java
@@ -16,7 +16,10 @@
 
 package com.salesforce.cdp.queryservice.interceptors;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
+import com.salesforce.cdp.queryservice.model.MetadataCacheKey;
 import com.salesforce.cdp.queryservice.util.Constants;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
@@ -29,32 +32,58 @@ import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class MetadataCacheInterceptor implements Interceptor {
     private final QueryServiceConnection connection;
+    private Cache<MetadataCacheKey, String> metaDataCache;
 
     public MetadataCacheInterceptor(QueryServiceConnection connection) {
         this.connection = connection;
+        this.metaDataCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(connection.getMetaDataCacheDurationInMs(), TimeUnit.MILLISECONDS)
+                .maximumSize(10).build();
     }
 
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
         Request request = chain.request();
-        String responseString = connection.getMetadataFromCacheIfPresent();
         Response response;
+        String responseString = getMetadataFromCacheIfPresent();
+
+        Response.Builder responseBuilder = new Response.Builder().code(HttpStatus.SC_OK).
+                request(request).protocol(Protocol.HTTP_1_1).
+                message("OK");
+
         if (responseString != null) {
             log.trace("Getting the metadata response from local cache");
-            response = new Response.Builder().code(HttpStatus.SC_OK).
-                    request(request).protocol(Protocol.HTTP_1_1).
-                    message("OK").
-                    addHeader("from-local-cache", Constants.TRUE_STR).
-                    body(ResponseBody.create(responseString, MediaType.parse(Constants.JSON_CONTENT))).build();
+            responseBuilder.addHeader("from-local-cache", Constants.TRUE_STR);
         } else {
             log.trace("Cache miss for metadata response. Getting from server");
             response = chain.proceed(request);
+
+            if(!response.isSuccessful()) {
+                return response;
+            } else {
+                log.info("Caching the response");
+                responseString = response.body().string();
+                cacheMetadata(responseString);
+            }
         }
-        return response;
+
+        responseBuilder.body(ResponseBody.create(responseString, MediaType.parse(Constants.JSON_CONTENT)));
+        return responseBuilder.build();
+    }
+
+    private void cacheMetadata(String response) {
+        MetadataCacheKey cacheKey = connection.getMetadataCacheKey();
+        metaDataCache.put(cacheKey, response);
+    }
+
+    public String getMetadataFromCacheIfPresent() {
+        MetadataCacheKey cacheKey = connection.getMetadataCacheKey();
+        return metaDataCache.getIfPresent(cacheKey);
     }
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/model/MetadataCacheKey.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/model/MetadataCacheKey.java
@@ -1,0 +1,16 @@
+package com.salesforce.cdp.queryservice.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class MetadataCacheKey {
+    private String tenantUrl;
+    private String dataspace;
+
+    public MetadataCacheKey(String tenantUrl, String dataspace) {
+        this.tenantUrl = tenantUrl;
+        this.dataspace = dataspace;
+    }
+}

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -77,6 +77,7 @@ public class Constants {
     public static final String PD = "password";
     public static final String PRIVATE_KEY = "privateKey";
     public static final String MAX_RETRIES = "maxRetries";
+    public static final String RESULT_SET_METADATA_CACHE_DURATION_IN_MS = "metaDataCacheDurationInMs";
 
     // Response Constants
     public static final String MESSAGE = "message";
@@ -89,6 +90,7 @@ public class Constants {
     // Integer Constants
     public static final int REST_TIME_OUT = 600;
     public static final Integer MAX_LIMIT = 49999;
+    public static final int RESULT_SET_METADATA_CACHE_DURATION_IN_MS_VALUE = 600000;
 
     // Token Constants
     public static final String GRANT_TYPE_NAME = "grant_type";

--- a/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
@@ -19,7 +19,6 @@ package com.salesforce.cdp.queryservice.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -48,15 +47,6 @@ public class HttpHelper {
 
     public static <T> T handleSuccessResponse(Response response, Class<T> type) throws IOException {
         String responseString = response.body().string();
-        return handleSuccessResponse(responseString, type);
-    }
-
-    public static <T> T handleSuccessResponseWithCache(Response response, Class<T> type, QueryServiceConnection connection) throws IOException {
-        String responseString = response.body().string();
-        if (response.headers().get("from-local-cache") == null) {
-            log.info("Caching the response");
-            connection.cacheMetadata(responseString);
-        }
         return handleSuccessResponse(responseString, type);
     }
 

--- a/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
@@ -45,11 +45,16 @@ public class HttpHelper {
         throw new IOException(message);
     }
 
-    public static <T> T handleSuccessResponse(Response response, Class<T> type, boolean cacheResponse) throws IOException {
+    public static <T> T handleSuccessResponse(Response response, Class<T> type) throws IOException {
         String responseString = response.body().string();
-        if (response.headers().get("from-local-cache") == null && cacheResponse) {
+        return handleSuccessResponse(responseString, type);
+    }
+
+    public static <T> T handleSuccessResponseWithCache(Response response, Class<T> type, String cacheKey) throws IOException {
+        String responseString = response.body().string();
+        if (response.headers().get("from-local-cache") == null) {
             log.info("Caching the response");
-            MetadataCacheUtil.cacheMetadata(response.request().url().toString(), responseString);
+            MetadataCacheUtil.cacheMetadata(cacheKey, responseString);
         }
         return handleSuccessResponse(responseString, type);
     }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
@@ -19,6 +19,7 @@ package com.salesforce.cdp.queryservice.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -50,11 +51,11 @@ public class HttpHelper {
         return handleSuccessResponse(responseString, type);
     }
 
-    public static <T> T handleSuccessResponseWithCache(Response response, Class<T> type, String cacheKey) throws IOException {
+    public static <T> T handleSuccessResponseWithCache(Response response, Class<T> type, QueryServiceConnection connection) throws IOException {
         String responseString = response.body().string();
         if (response.headers().get("from-local-cache") == null) {
             log.info("Caching the response");
-            MetadataCacheUtil.cacheMetadata(cacheKey, responseString);
+            connection.cacheMetadata(responseString);
         }
         return handleSuccessResponse(responseString, type);
     }

--- a/src/test/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptorTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptorTest.java
@@ -18,6 +18,7 @@ package com.salesforce.cdp.queryservice.interceptors;
 
 import com.salesforce.cdp.queryservice.ResponseEnum;
 import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
+import com.salesforce.cdp.queryservice.model.MetadataCacheKey;
 import com.salesforce.cdp.queryservice.util.Constants;
 import com.salesforce.cdp.queryservice.util.MetadataCacheUtil;
 import okhttp3.*;
@@ -50,6 +51,7 @@ public class MetadataCacheInterceptorTest {
 
     @Test
     public void testMetadataRequestWithNoCachePresent() throws IOException {
+        when(connection.getMetadataCacheKey()).thenReturn(new MetadataCacheKey("mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com", "default"));
         doReturn(buildResponse(200, EMPTY_RESPONSE)).doReturn(buildResponse(200, QUERY_RESPONSE)).when(chain).proceed(any(Request.class));
         metadataCacheInterceptor.intercept(chain);
         verify(chain, times(1)).proceed(any(Request.class));

--- a/src/test/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptorTest.java
+++ b/src/test/java/com/salesforce/cdp/queryservice/interceptors/MetadataCacheInterceptorTest.java
@@ -17,11 +17,13 @@
 package com.salesforce.cdp.queryservice.interceptors;
 
 import com.salesforce.cdp.queryservice.ResponseEnum;
+import com.salesforce.cdp.queryservice.core.QueryServiceConnection;
 import com.salesforce.cdp.queryservice.util.Constants;
 import com.salesforce.cdp.queryservice.util.MetadataCacheUtil;
 import okhttp3.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.io.IOException;
 
@@ -35,11 +37,14 @@ public class MetadataCacheInterceptorTest {
     private Interceptor.Chain chain;
 
     private MetadataCacheInterceptor metadataCacheInterceptor;
+    @Mock
+    QueryServiceConnection connection;
 
     @Before
     public void init() {
         chain = mock(Interceptor.Chain.class);
-        metadataCacheInterceptor = new MetadataCacheInterceptor();
+        connection = mock(QueryServiceConnection.class);
+        metadataCacheInterceptor = new MetadataCacheInterceptor(connection);
         doReturn(buildRequest()).when(chain).request();
     }
 
@@ -48,13 +53,6 @@ public class MetadataCacheInterceptorTest {
         doReturn(buildResponse(200, EMPTY_RESPONSE)).doReturn(buildResponse(200, QUERY_RESPONSE)).when(chain).proceed(any(Request.class));
         metadataCacheInterceptor.intercept(chain);
         verify(chain, times(1)).proceed(any(Request.class));
-    }
-
-    @Test
-    public void testMetadataFromCache()  throws IOException {
-        MetadataCacheUtil.cacheMetadata("https://mjrgg9bzgy2dsyzvmjrgkmzzg1.c360a.salesforce.com" + Constants.CDP_URL + Constants.METADATA_URL, TABLE_METADATA.getResponse());
-        metadataCacheInterceptor.intercept(chain);
-        verify(chain, times(0)).proceed(any(Request.class));
     }
 
     private Request buildRequest() {


### PR DESCRIPTION
This commit resolves the caching problem that occurred when two different connections were used, resulting in the same metadata being retrieved due to caching based on the tenantUrl. The cache key has now been updated to include both the tenantUrl and dataspace for improved caching strategy.