### PR TITLE
chore(codeowners): add valid GUSINFO for OSPO compliance

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:CDP Query Service (IN),CDP Query Service (India)


### PR DESCRIPTION
Add the required CODEOWNERS #GUSINFO line pointing at the repo's owning GUS Scrum Team and Product Tag, per OSPO policy. Both records are Active in GUS.

Scrum Team:  CDP Query Service (IN)
Product Tag: CDP Query Service (India)